### PR TITLE
Update copy popup

### DIFF
--- a/gallery.js
+++ b/gallery.js
@@ -71,7 +71,7 @@ document.addEventListener('DOMContentLoaded', () => {
         await navigator.clipboard.write([
           new ClipboardItem({[blob.type]: blob})
         ]);
-        alert('Image URL copied to clipboard!');
+        alert('Image copied to clipboard!');
       } catch (err) {
         alert('Failed to copy image.');
       }


### PR DESCRIPTION
I noticed the popup when the user clicks 'Copy' still said 'Image URL copied to clipboard' which is no longer accurate (now that we're coping the image itself). I made a small change to that text to just say 'Image copied to clipboard' instead in case users get confused.